### PR TITLE
Fix containerd symlink failure

### DIFF
--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -6,6 +6,7 @@
   with_items:
   - "{{ containerd_release_dir }}"
   - "{{ containerd_config_dir }}"
+  - "{{ bin_dir }}"
 
 - name: Containerd | Download binaries
   unarchive:


### PR DESCRIPTION
During the step `Containerd | Symlink containerd binaries`, Ansible try to link all files in `{{ containerd_release_dir }}/bin` to `{{ bin_dir }}` (`/opt/bin` as default).

But, on Ubuntu (and maybe other distro), `/opt/bin` does not exists.

So I add `{{ bin_dir }}` on the first step, when Ansible creates required folders.