### PR TITLE
style: use fqcn for task plugins names

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -3,4 +3,3 @@
 skip_list:
  - 'role-name'  # Role name {} does not match ``^[a-z][a-z0-9_]+$`` pattern
  - 'no-changed-when'  # Commands should not change things if nothing needs doing
- - 'fqcn-builtins'

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: Containerd | Restart containerd
-  systemd:
+  ansible.builtin.systemd:
     state: restarted
     name: containerd.service
     daemon_reload: true

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -4,13 +4,13 @@
   become: true
   pre_tasks:
     - name: "Pre-task | Update apt-cache"
-      apt:
+      ansible.builtin.apt:
         update_cache: true
         cache_valid_time: 600
       when: "ansible_os_family == 'Debian'"
 
     - name: "Pre-task | Create required directories"
-      file:
+      ansible.builtin.file:
         mode: "u+rw,g+r,o+r"
         path: "{{ item }}"
         state: "directory"
@@ -19,5 +19,5 @@
 
   tasks:
     - name: "Include symplegma-containerd"
-      include_role:
+      ansible.builtin.include_role:
         name: "symplegma-containerd"

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -6,5 +6,5 @@
   gather_facts: false
   tasks:
   - name: Example assertion
-    assert:
+    ansible.builtin.assert:
       that: true

--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -1,6 +1,6 @@
 ---
 - name: Containerd | Ensure containerd required directory exist
-  file:
+  ansible.builtin.file:
     path: "{{ item }}"
     state: directory
     mode: "u+rw,g+r,o+r"
@@ -9,7 +9,7 @@
     - "{{ containerd_config_dir }}"
 
 - name: Containerd | Download runc
-  get_url:
+  ansible.builtin.get_url:
     url: "{{ runc_release_url }}"
     mode: 0755
     dest: "{{ bin_dir }}/runc"
@@ -17,34 +17,34 @@
   notify: restart containerd
 
 - name: Containerd | Download binaries
-  unarchive:
+  ansible.builtin.unarchive:
     src: "{{ containerd_release_url }}"
     dest: "{{ containerd_release_dir }}"
     remote_src: true
   notify: restart containerd
 
 - name: Containerd | Drop systemd unit
-  template:
+  ansible.builtin.template:
     src: containerd.service.j2
     dest: /etc/systemd/system/containerd.service
     mode: 'u+rw,g+r,o+r'
   notify: restart containerd
 
 - name: Containerd | Drop containerd config
-  template:
+  ansible.builtin.template:
     src: config.toml.j2
     dest: /etc/containerd/config.toml
     mode: 'u+rw,g+r,o+r'
   notify: restart containerd
 
 - name: Containerd | List containerd binaries
-  find:
+  ansible.builtin.find:
     paths: "{{ containerd_release_dir }}/bin"
   register: containerd_binaries
   notify: restart containerd
 
 - name: Containerd | Symlink containerd binaries
-  file:
+  ansible.builtin.file:
     src: "{{ item.path }}"
     dest: "{{ bin_dir }}/{{ item.path | basename }}"
     state: link
@@ -52,10 +52,10 @@
   notify: restart containerd
 
 - name: Containerd | Trigger "restart containerd" handler
-  meta: flush_handlers
+  ansible.builtin.meta: flush_handlers
 
 - name: Containerd | Enable Containerd unit
-  systemd:
+  ansible.builtin.systemd:
     name: containerd.service
     state: started
     enabled: true


### PR DESCRIPTION
Another PR to use fqcn in project and make ansible-lint complain without it